### PR TITLE
Remove unnecessary use of `sudo`

### DIFF
--- a/security.sh
+++ b/security.sh
@@ -10,41 +10,41 @@ then
 fi
 
 # Firewall
-sudo ufw enable
+ufw enable
 
 # Updates
-sudo apt-get -y upgrade
-sudo apt-get -y update
+apt-get -y upgrade
+apt-get -y update
 
 # Lock Out Root User
-sudo passwd -l root
+passwd -l root
 
 # Disable Guest Account
 echo "allow-guest=false" >> /etc/lightdm/lightdm.conf
 
 # Configure Password Aging Controls
-sudo sed -i '/^PASS_MAX_DAYS/ c\PASS_MAX_DAYS   90' /etc/login.defs
-sudo sed -i '/^PASS_MIN_DAYS/ c\PASS_MIN_DAYS   10'  /etc/login.defs
-sudo sed -i '/^PASS_WARN_AGE/ c\PASS_WARN_AGE   7' /etc/login.defs
+sed -i '/^PASS_MAX_DAYS/ c\PASS_MAX_DAYS   90' /etc/login.defs
+sed -i '/^PASS_MIN_DAYS/ c\PASS_MIN_DAYS   10'  /etc/login.defs
+sed -i '/^PASS_WARN_AGE/ c\PASS_WARN_AGE   7' /etc/login.defs
 
 # Password Authentication
-sudo sed -i '1 s/^/auth optional pam_tally.so deny=5 unlock_time=900 onerr=fail audit even_deny_root_account silent\n/' /etc/pam.d/common-auth
+sed -i '1 s/^/auth optional pam_tally.so deny=5 unlock_time=900 onerr=fail audit even_deny_root_account silent\n/' /etc/pam.d/common-auth
 
 # Force Strong Passwords
-sudo apt-get -y install libpam-cracklib
-sudo sed -i '1 s/^/password requisite pam_cracklib.so retry=3 minlen=8 difok=3 reject_username minclass=3 maxrepeat=2 dcredit=1 ucredit=1 lcredit=1 ocredit=1\n/' /etc/pam.d/common-password
+apt-get -y install libpam-cracklib
+sed -i '1 s/^/password requisite pam_cracklib.so retry=3 minlen=8 difok=3 reject_username minclass=3 maxrepeat=2 dcredit=1 ucredit=1 lcredit=1 ocredit=1\n/' /etc/pam.d/common-password
 
 # MySQL
 echo -n "MySQL [Y/n] "
 read option
 if [[ $option =~ ^[Yy]$ ]]
 then
-  sudo apt-get -y install mysql-server
+  apt-get -y install mysql-server
   # Disable remote access
-  sudo sed -i '/bind-address/ c\bind-address = 127.0.0.1' /etc/mysql/my.cnf
-  sudo service mysql restart
+  sed -i '/bind-address/ c\bind-address = 127.0.0.1' /etc/mysql/my.cnf
+  service mysql restart
 else
-  sudo apt-get -y purge mysql*
+  apt-get -y purge mysql*
 fi
 
 # OpenSSH Server
@@ -52,12 +52,12 @@ echo -n "OpenSSH Server [Y/n] "
 read option
 if [[ $option =~ ^[Yy]$ ]]
 then
-  sudo apt-get -y install openssh-server
+  apt-get -y install openssh-server
   # Disable root login
-  sudo sed -i '/^PermitRootLogin/ c\PermitRootLogin no' /etc/ssh/sshd_config
-  sudo service ssh restart
+  sed -i '/^PermitRootLogin/ c\PermitRootLogin no' /etc/ssh/sshd_config
+  service ssh restart
 else
-  sudo apt-get -y purge openssh-server*
+  apt-get -y purge openssh-server*
 fi
 
 # VSFTPD
@@ -65,25 +65,25 @@ echo -n "VSFTP [Y/n] "
 read option
 if [[ $option =~ ^[Yy]$ ]]
 then
-  sudo apt-get -y install vsftpd
+  apt-get -y install vsftpd
   # Disable anonymous uploads
-  sudo sed -i '/^anon_upload_enable/ c\anon_upload_enable no' /etc/vsftpd.conf
-  sudo sed -i '/^anonymous_enable/ c\anonymous_enable=NO' /etc/vsftpd.conf
+  sed -i '/^anon_upload_enable/ c\anon_upload_enable no' /etc/vsftpd.conf
+  sed -i '/^anonymous_enable/ c\anonymous_enable=NO' /etc/vsftpd.conf
   # FTP user directories use chroot
-  sudo sed -i '/^chroot_local_user/ c\chroot_local_user=YES' /etc/vsftpd.conf
-  sudo service vsftpd restart
+  sed -i '/^chroot_local_user/ c\chroot_local_user=YES' /etc/vsftpd.conf
+  service vsftpd restart
 else
-  sudo apt-get -y purge vsftpd*
+  apt-get -y purge vsftpd*
 fi
 
 # Malware
-sudo apt-get -y purge hydra*
-sudo apt-get -y purge john*
-sudo apt-get -y purge nikto*
-sudo apt-get -y purge netcat*
+apt-get -y purge hydra*
+apt-get -y purge john*
+apt-get -y purge nikto*
+apt-get -y purge netcat*
 
 # Media Files
 for suffix in mp3 txt wav wma aac mp4 mov avi gif jpg png bmp img exe msi bat sh
 do
-  sudo find /home -name *.$suffix
+  find /home -name *.$suffix
 done


### PR DESCRIPTION
The script checks at the beginning that it is running as root, so using Sudo in an attempt to run programs with administrative privileges serves no purpose and may cause the script to break on systems that may not have Sudo installed.